### PR TITLE
fix typo in various files for the word 'JavaScript'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 </div>
 
 
-Yew Styles is a style framework for yew without Javascript dependencies
+Yew Styles is a style framework for yew without JavaScript dependencies
 
 ## Motivation
 The purpose of developing this project is first,
-provide a style framework for yew that doesn't require any Javascrit dependencies
+provide a style framework for yew that doesn't require any JavaScript dependencies
 also to create a layout system which is not far of the flexbox concept, and,
 to take the rust benefits and implement properties selected by enumeration
 in the most of the cases which makes fast for developing applications and avoids the practice try and error

--- a/crate/src/page/home_page.rs
+++ b/crate/src/page/home_page.rs
@@ -34,7 +34,7 @@ impl Component for HomePage {
                 </Item>
                 <Item layouts=vec!(ItemLayout::ItXl(8), ItemLayout::ItM(10), ItemLayout::ItXs(12))>
                     <h2>{"Motivation"}</h2>
-                    <p>{"The purpose of developing this project is first, provide a style framework for yew that doesn't require any Javascrit dependencies
+                    <p>{"The purpose of developing this project is first, provide a style framework for yew that doesn't require any JavaScript dependencies
                     also to create a layout system which is not far of the flexbox concept,
                     and, to take the rust benefits and implement properties selected by enumeration
                      in the most of the cases which makes fast for developing applications and avoids the practice try and error"}</p>

--- a/crate/yew_styles/README.md
+++ b/crate/yew_styles/README.md
@@ -1,9 +1,9 @@
 # Yew Styles
-Yew Styles is a style framework for yew without Javascript dependencies
+Yew Styles is a style framework for yew without JavaScript dependencies
 
 ## Motivation
 The purpose of developing this project is first,
-provide a style framework for yew that doesn't require any Javascrit dependencies
+provide a style framework for yew that doesn't require any JavaScript dependencies
 also to create a layout system which is not far of the flexbox concept, and,
 to take the rust benefits and implement properties selected by enumeration
 in the most of the cases which makes fast for developing applications and avoids the practice try and error

--- a/crate/yew_styles/src/lib.rs
+++ b/crate/yew_styles/src/lib.rs
@@ -1,10 +1,10 @@
 //! # Yew Styles
 //!
-//! Yew Styles is a style framework for yew without Javascript dependencies
+//! Yew Styles is a style framework for yew without JavaScript dependencies
 //!
 //! ## Motivation
 //! The purpose of developing this project is first,
-//! provide a style framework for yew that doesn't require any Javascrit dependencies
+//! provide a style framework for yew that doesn't require any JavaScript dependencies
 //! also to create a layout system which is not far of the flexbox concept, and,
 //! to take the rust benefits and implement properties selected by enumeration
 //! in the most of the cases which makes fast for developing applications and avoids the practice try and error


### PR DESCRIPTION
This should close issue #58.

I was not able to run the unit tests successfully however.

This was the error I received when I tried running them: 

> error: test failed, to rerun pass '--lib'

> Caused by:
>   could not execute process `wasm-bindgen-test-runner /Users/alexstrand/Documents/projects/yew_styles/crate/yew_styles/target/wasm32-unknown-unknown/debug/deps/yew_styles-32d7c6a96ad10ebb.wasm` (never executed)

I even installed the wasm target from the yew docs before I ran thew tests: 

> rustup target add wasm32-unknown-unknown

Is it an issue if the tests fail to run my machine this PR, since it's a documentation change only?

I'm running macOS Mojave at the moment. 
